### PR TITLE
update models and seeding logic

### DIFF
--- a/models/Score.js
+++ b/models/Score.js
@@ -1,0 +1,37 @@
+const { Model, DataTypes } = require('sequelize');
+const sequelize = require('../config/connection');
+
+class Score extends Model { }
+
+Score.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'User',
+        key: 'id'
+      }
+    },
+    high_score: {
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+      allowNull: false
+    },
+  },
+  {
+    sequelize,
+    timestamps: false,
+    freezeTableName: true,
+    underscored: true,
+    modelName: 'score',
+  }
+);
+
+module.exports = Score;

--- a/models/Scores.js
+++ b/models/Scores.js
@@ -1,1 +1,0 @@
-// model for high scores

--- a/models/User.js
+++ b/models/User.js
@@ -4,9 +4,9 @@ const sequelize = require('../config/connection');
 
 // Will come back later and un-comment 
 class User extends Model {
-//   checkPassword(loginPw) {
-//     return bcrypt.compareSync(loginPw, this.password);
-//   }
+  //   checkPassword(loginPw) {
+  //     return bcrypt.compareSync(loginPw, this.password);
+  //   }
 }
 
 User.init(
@@ -18,12 +18,12 @@ User.init(
       autoIncrement: true,
     },
     first_name: {
-        type: DataTypes.STRING,
-        allowNull: false,
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     last_name: {
-        type: DataTypes.STRING,
-        allowNull: false,
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     username: {
       type: DataTypes.STRING,

--- a/models/index.js
+++ b/models/index.js
@@ -1,5 +1,15 @@
 // Model index
-const User = require(`./User`);
-const Scores = require(`./Scores`);
+const User = require('./User');
+const Score = require('./Score');
 
-module.exports = { User, Scores };
+// A user has one score
+User.hasOne(Score, {
+    foreignKey: 'id'
+});
+
+// A score belongs to one user
+Score.belongsTo(User, {
+    foreignKey: 'id'
+});
+
+module.exports = { User, Score };

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -1,1 +1,15 @@
-// seeds index
+const sequelize = require('../config/connection');
+const seedUser = require('./userData');
+const seedScore = require('./scoreData');
+
+const seedAll = async () => {
+  await sequelize.sync({ force: true });
+
+  await seedUser();
+
+  await seedScore();
+
+  process.exit(0);
+};
+
+seedAll();

--- a/seeds/scoreData.js
+++ b/seeds/scoreData.js
@@ -1,0 +1,34 @@
+const { Score } = require('../models');
+
+const scoredata = [
+  {
+    id: 1,
+    user_id: 1,
+    high_score: 77,
+  },
+  {
+    id: 2,
+    user_id: 5,
+    high_score: 323,
+  },
+  {
+    id: 3,
+    user_id: 2,
+    high_score: 513,
+  },
+  {
+    id: 4,
+    user_id: 4,
+    high_score: 600,
+  },
+  {
+    id: 5,
+    user_id: 3,
+    high_score: 15,
+  },
+
+];
+
+const seedScore = () => Score.bulkCreate(scoredata);
+
+module.exports = seedScore;

--- a/seeds/userData.js
+++ b/seeds/userData.js
@@ -1,0 +1,43 @@
+const { User } = require('../models');
+
+const userdata = [
+  {
+    id: 1,
+    first_name: 'Giorno',
+    last_name: 'Giovanna',
+    username: 'ggiorno',
+    password: 'password1',
+  },
+  {
+    id: 2,
+    first_name: 'Hayden',
+    last_name: 'McBride',
+    username: 'haymcb2',
+    password: 'password2',
+  },
+  {
+    id: 3,
+    first_name: 'Desirae',
+    last_name: 'Solis',
+    username: 'd_solis',
+    password: 'password3',
+  },
+  {
+    id: 4,
+    first_name: 'Kody',
+    last_name: 'Hart',
+    username: 'hartko22',
+    password: 'password4',
+  },
+  {
+    id: 5,
+    first_name: 'Skyler',
+    last_name: 'Mercado',
+    username: 'bigsky7',
+    password: 'password5',
+  },
+];
+
+const seedUser = () => User.bulkCreate(userdata);
+
+module.exports = seedUser;


### PR DESCRIPTION
Update models for User and Score - see wireframe doc for table layout

User model does not yet have bcrypt functionality for passwords.

Added seed logic for both User and Score models

First, open MySQL and run "SOURCE db/schema.sql;"
Then, run "node seeds/index.js" in the terminal to seed tables