### PR TITLE
Debug Empty User Search

### DIFF
--- a/public/js/usersearch.js
+++ b/public/js/usersearch.js
@@ -4,7 +4,13 @@ const searchInput = document.querySelector("#usf-input");
 const searchHandler = async (event) => {
   event.preventDefault();
   const query = await searchInput.value.trim();
-  window.location.replace(`/userinfo/${query}`);
+  const response = await fetch(`/userinfo/${query}`);
+  if (response.ok) {
+    window.location.replace(`/userinfo/${query}`);
+  } else {
+    alert("No user found. Please try again");
+  }
+  
 };
 
 searchForm.addEventListener("submit", searchHandler);


### PR DESCRIPTION
Fixed a bug that would render an empty page if someone searched for a user that didn't exist, or if the query couldn't find a user based on the search criteria.

Now there will be an alert that pops up saying there was an error while searching, and will keep the user on the search page.